### PR TITLE
Filtering fix

### DIFF
--- a/CCB/step_2.nf
+++ b/CCB/step_2.nf
@@ -231,7 +231,7 @@ workflow {
     .combine(fastq_demu, by:0)
     .set {grouping_out}
 
-//    corrected_merge(err_corr(grouping_out).collect())
+    corrected_merge(err_corr(grouping_out).collect())
 
 
 }


### PR DESCRIPTION
Old filtering step failed with barcodes larger than 1.5 GB. I now simply split them up into subsets. 